### PR TITLE
Fix build error on HashLink

### DIFF
--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -939,11 +939,10 @@ class Shader
 
 						Reflect.setField(__data, name, parameter);
 
-						if (__isGenerated && thisHasField(name)) Reflect.setProperty(this, name, parameter);
-
 						try
 						{
 							if (__isGenerated) Reflect.setField(this, name, parameter);
+							if (__isGenerated && thisHasField(name)) Reflect.setProperty(this, name, parameter);
 						}
 						catch (e:Dynamic)
 						{

--- a/src/openfl/net/FileReferenceList.hx
+++ b/src/openfl/net/FileReferenceList.hx
@@ -1,7 +1,7 @@
 package openfl.net;
 
 #if !flash
-#if cpp
+#if (cpp || hl)
 import haxe.io.Path;
 import openfl.events.Event;
 import openfl.events.EventDispatcher;


### PR DESCRIPTION
Fixes a compile issue from HaxeUI using FileReferenceList which is only being enabled for cpp now