### PR TITLE
Fix advanced blend equation not rendering

### DIFF
--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -73,6 +73,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	@:noCompletion private static var __staticDefaultDisplayShader:DisplayObjectShader;
 	@:noCompletion private static var __staticDefaultGraphicsShader:GraphicsShader;
 	@:noCompletion private static var __staticMaskShader:Context3DMaskShader;
+	@:noCompletion private static var __complexBlendsSupported:Null<Bool>;
 
 	@:noCompletion private var __context3D:Context3D;
 	@:noCompletion private var __clipRects:Array<Rectangle>;
@@ -107,8 +108,6 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	@:noCompletion private var __values:Array<Float>;
 	@:noCompletion private var __width:Int;
 
-	@:noCompletion private var _complexBlendsSupported:Bool;
-
 	@:noCompletion private function new(context:Context3D, defaultRenderTarget:BitmapData = null)
 	{
 		super();
@@ -142,7 +141,8 @@ class OpenGLRenderer extends DisplayObjectRenderer
 		}
 		#end
 
-		_complexBlendsSupported = gl.getSupportedExtensions().contains("KHR_blend_equation_advanced");
+		if (__complexBlendsSupported == null)
+			__complexBlendsSupported = gl.getSupportedExtensions().contains("KHR_blend_equation_advanced");
 
 		#if (js && html5)
 		__softwareRenderer = new CanvasRenderer(null);
@@ -1046,7 +1046,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 
 		__blendMode = value;
 
-		if (_complexBlendsSupported)
+		if (__complexBlendsSupported)
 		{
 			var equation:Null<Int> = switch (value)
 			{

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -625,10 +625,22 @@ class Shader
 			extensions += "#extension " + ext.name + " : " + ext.behavior + "\n";
 		}
 
+		var complexBlendsSupported = OpenGLRenderer.__complexBlendsSupported && isFragment &&
+			(!StringTools.startsWith(__glVersion, "1") || __glVersion == "150");
+
+		if (complexBlendsSupported)
+		{
+			extensions += "#extension GL_KHR_blend_equation_advanced : enable\n";
+
+			// compiling without this gives the error
+			// 'gl_SampleID' : required extension not requested: GL_ARB_sample_shading
+			extensions += "#extension GL_ARB_sample_shading : enable\n";
+		}
+
 		// #version must be the first directive and cannot be repeated,
 		// while #extension directives must be before any non-preprocessor tokens.
 
-		return "#version "
+		var prefix = "#version "
 			+ __glVersion
 			+ "
       "
@@ -644,6 +656,13 @@ class Shader
 			+ "
 				#endif
 				";
+
+		if (complexBlendsSupported)
+		{
+			prefix += "#ifdef GL_KHR_blend_equation_advanced\nlayout (blend_support_all_equations) out;\n#endif\n";
+		}
+
+		return prefix;
 	}
 
 	@:noCompletion private function __initGL():Void


### PR DESCRIPTION
### **NOTE:** `OpenGLRenderer._complexBlendsSupported` was renamed to `OpenGLRenderer.__complexBlendsSupported` (notice the additional underscore) and made static. This will require a change in the Funkin' PR.

---

The advanced blend equation extension requires a change in the fragment shader in order to work.
>  Advanced blending equations require the use of a fragment shader with a
    matching "blend_support" layout qualifier.  If the current blend equation
    is found in table X.1 or X.2, and the active fragment shader does not
    include the layout qualifier matching the blend equation or
    "blend_support_all_equations", the error INVALID_OPERATION is generated
https://registry.khronos.org/OpenGL/extensions/KHR/KHR_blend_equation_advanced.txt

The required changes will be automatically injected into any shader with the GLSL version >=150, as that's the minimum required version. This also means that any sprites that use a complex blend **will need** to also use a shader with a higher GLSL version.