### PR TITLE
Don't use complex variants of standard blend modes

### DIFF
--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -1064,11 +1064,8 @@ class OpenGLRenderer extends DisplayObjectRenderer
 
 			var equation:Null<Int> = switch (value)
 			{
-				case MULTIPLY: 0x9294; // MULTIPLY_KHR
-				case SCREEN: 0x9295; // SCREEN_KHR
 				case OVERLAY: 0x9296; // OVERLAY_KHR
 				case DARKEN: 0x9297; // DARKEN_KHR
-				case LIGHTEN: 0x9298; // LIGHTEN_KHR
 				case HARDLIGHT: 0x929B; // HARDLIGHT_KHR
 				case DIFFERENCE: 0x929E; // DIFFERENCE_KHR
 				case COLORDODGE: 0x9299; // COLORDODGE_KHR


### PR DESCRIPTION
Fixes an issue reported in the Funkin' Contributors discord, where pixel note splashes overdraw each other:

<img width="609" height="230" alt="image" src="https://github.com/user-attachments/assets/99581bd6-5386-43bd-b167-da841a79271f" />

This happened because the note splashes use the SCREEN blend mode, which has both a standard and complex implementation. Because of this, they weren't marked as a KHR blend mode in `FunkinCamera`, which ended up not breaking up the sprite batch, which caused the same issue as https://github.com/FunkinCrew/Funkin/pull/6786.

The easiest solution would be to just use the standard implementation of the blend mode, which is what's done here.