### PR TITLE
Fix Couple of issues in OpenGLRenderer

### DIFF
--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -54,6 +54,11 @@ import lime.math.Matrix4;
 @:allow(openfl.text)
 class OpenGLRenderer extends DisplayObjectRenderer
 {
+	@:noCompletion private static var __blendMinMaxSupported:Null<Bool>;
+	@:noCompletion private static var __complexBlendsSupported:Null<Bool>;
+	@:noCompletion private static var __coherentBlendsSupported:Null<Bool>;
+	@:noCompletion private static var __sRGBWriteControlSupported:Null<Bool>;
+
 	@:noCompletion private static var __alphaValue:Array<Float> = [1];
 	@:noCompletion private static var __colorMultipliersValue:Array<Float> = [0, 0, 0, 0];
 	@:noCompletion private static var __colorOffsetsValue:Array<Float> = [0, 0, 0, 0];
@@ -73,9 +78,6 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	@:noCompletion private static var __staticDefaultDisplayShader:DisplayObjectShader;
 	@:noCompletion private static var __staticDefaultGraphicsShader:GraphicsShader;
 	@:noCompletion private static var __staticMaskShader:Context3DMaskShader;
-	@:noCompletion private static var __sRGBWriteControlSupported:Null<Bool>;
-	@:noCompletion private static var __complexBlendsSupported:Null<Bool>;
-	@:noCompletion private static var __coherentBlendsSupported:Null<Bool>;
 
 	@:noCompletion private var __context3D:Context3D;
 	@:noCompletion private var __clipRects:Array<Rectangle>;
@@ -143,12 +145,13 @@ class OpenGLRenderer extends DisplayObjectRenderer
 		}
 		#end
 
-		#if lime
+		final exts = __gl.getSupportedExtensions();
+
 		if (__context.type == OPENGLES)
 		{
 			if (__sRGBWriteControlSupported == null)
 			{
-				__sRGBWriteControlSupported = gl.getSupportedExtensions().contains("EXT_sRGB_write_control");
+				__sRGBWriteControlSupported = exts.contains("EXT_sRGB_write_control");
 			}
 
 			if (__sRGBWriteControlSupported)
@@ -156,13 +159,18 @@ class OpenGLRenderer extends DisplayObjectRenderer
 				gl.disable(0x8DB9); // GL_FRAMEBUFFER_SRGB_EXT
 			}
 		}
-		#end
 
+		if (__blendMinMaxSupported == null)
+		{
+			__blendMinMaxSupported = exts.contains("EXT_blend_minmax");
+		}
 		if (__complexBlendsSupported == null)
 		{
-			var extensions = gl.getSupportedExtensions();
-			__complexBlendsSupported = extensions.contains("KHR_blend_equation_advanced");
-			__coherentBlendsSupported = extensions.contains("KHR_blend_equation_advanced_coherent");
+			__complexBlendsSupported = exts.contains("KHR_blend_equation_advanced");
+		}
+		if (__coherentBlendsSupported == null)
+		{
+			__coherentBlendsSupported = exts.contains("KHR_blend_equation_advanced_coherent");
 		}
 
 		#if (js && html5)
@@ -1080,60 +1088,65 @@ class OpenGLRenderer extends DisplayObjectRenderer
 				__context3D.__setGLBlend(cacheBlendState);
 			}
 
-			var equation:Null<Int> = switch (value)
-			{
-				case OVERLAY: 0x9296; // OVERLAY_KHR
-				case DARKEN: 0x9297; // DARKEN_KHR
-				case HARDLIGHT: 0x929B; // HARDLIGHT_KHR
-				case DIFFERENCE: 0x929E; // DIFFERENCE_KHR
-				case COLORDODGE: 0x9299; // COLORDODGE_KHR
-				case COLORBURN: 0x929A; // COLORBURN_KHR
-				case SOFTLIGHT: 0x929C; // SOFTLIGHT_KHR
-				case EXCLUSION: 0x92A0; // EXCLUSION_KHR
-				case HUE: 0x92AD; // HSL_HUE_KHR
-				case SATURATION: 0x92AE; // HSL_SATURATION_KHR
-				case COLOR: 0x92AF; // HSL_COLOR_KHR
-				case LUMINOSITY: 0x92B0; // HSL_LUMINOSITY_KHR
-				default: null;
-			}
-
-			if (equation != null)
-			{
-				__context3D.__setGLBlendEquation(equation);
 				__context3D.__usingComplexBlend = true;
-				return;
-			}
+			switch (value) {
+				case DARKEN:
+					if (__context3D.__usingComplexBlend = !__blendMinMaxSupported)
+						__context3D.__setGLBlendEquation(0x9297); // DARKEN_KHR
+				case DIFFERENCE: __context3D.__setGLBlendEquation(0x929E); // DIFFERENCE_KHR
+				case HARDLIGHT: __context3D.__setGLBlendEquation(0x929B); // HARDLIGHT_KHR
+				case LIGHTEN:
+					if (__context3D.__usingComplexBlend = !__blendMinMaxSupported)
+						__context3D.__setGLBlendEquation(0x9298); // LIGHTEN_KHR
+				//case MULTIPLY: __context3D.__setGLBlendEquation(0x9294); // MULTIPLY_KHR
+				case OVERLAY: __context3D.__setGLBlendEquation(0x9296); // OVERLAY_KHR
+				//case SCREEN: __context3D.__setGLBlendEquation(0x9295); // SCREEN_KHR
+				case COLORDODGE: __context3D.__setGLBlendEquation(0x929A); // COLORDODGE_KHR
+				case COLORBURN: __context3D.__setGLBlendEquation(0x9299); // COLORBURN_KHR
+				case SOFTLIGHT: __context3D.__setGLBlendEquation(0x929C); // SOFTLIGHT_KHR
+				case EXCLUSION: __context3D.__setGLBlendEquation(0x92A0); // EXCLUSION_KHR
+				case HUE: __context3D.__setGLBlendEquation(0x92AD); // HSL_HUE_KHR
+				case SATURATION: __context3D.__setGLBlendEquation(0x92AE); // HSL_SATURATION_KHR
+				case COLOR: __context3D.__setGLBlendEquation(0x92AF); // HSL_COLOR_KHR
+				case LUMINOSITY: __context3D.__setGLBlendEquation(0x92B0); // HSL_LUMINOSITY_KHR
+				default: __context3D.__usingComplexBlend = false;
 		}
 
-		__context3D.__usingComplexBlend = false;
+			if (__context3D.__usingComplexBlend) return;
+		}
 
 		switch (value)
 		{
-			case ADD:
-				__context3D.setBlendFactors(ONE, ONE);
-
-			case MULTIPLY:
-				__context3D.setBlendFactors(DESTINATION_COLOR, ONE_MINUS_SOURCE_ALPHA);
-
-			case SCREEN:
-				__context3D.setBlendFactors(ONE, ONE_MINUS_SOURCE_COLOR);
-
+			case ADD: __context3D.setBlendFactors(ONE, ONE);
+			case ALPHA: __context3D.setBlendFactors(SOURCE_ALPHA, ONE_MINUS_SOURCE_ALPHA);
+			case DARKEN:
+				if (__blendMinMaxSupported)
+				{
+					__context3D.setBlendFactors(ONE, ONE_MINUS_SOURCE_ALPHA);
+					__context3D.__setGLBlendEquation(0x8007); // GL_MIN
+				}
+				else
+				{
+					__context3D.setBlendFactors(DESTINATION_COLOR, ONE_MINUS_SOURCE_ALPHA);
+				}
+			case ERASE: __context3D.setBlendFactors(ZERO, ONE_MINUS_SOURCE_ALPHA);
+			case INVERT: __context3D.setBlendFactorsSeparate(ONE_MINUS_DESTINATION_COLOR, ONE_MINUS_SOURCE_ALPHA, ZERO, ONE);
+			case LIGHTEN:
+				if (__blendMinMaxSupported)
+				{
+					__context3D.setBlendFactors(ONE, ONE);
+					__context3D.__setGLBlendEquation(0x8008); // GL_MAX
+				}
+				else
+				{
+					__context3D.setBlendFactors(ONE, ONE);
+				}
+			case MULTIPLY: __context3D.setBlendFactors(DESTINATION_COLOR, ONE_MINUS_SOURCE_ALPHA);
+			case SCREEN: __context3D.setBlendFactors(ONE, ONE_MINUS_SOURCE_COLOR);
 			case SUBTRACT:
 				__context3D.setBlendFactors(ONE, ONE);
-				__context3D.__setGLBlendEquation(__gl.FUNC_REVERSE_SUBTRACT);
-
-			#if desktop
-			case DARKEN:
-				__context3D.setBlendFactors(ONE, ONE);
-				__context3D.__setGLBlendEquation(0x8007); // GL_MIN
-
-			case LIGHTEN:
-				__context3D.setBlendFactors(ONE, ONE);
-				__context3D.__setGLBlendEquation(0x8008); // GL_MAX
-			#end
-
-			default:
-				__context3D.setBlendFactors(ONE, ONE_MINUS_SOURCE_ALPHA);
+				__context3D.__setGLBlendEquation(0x800B); // GL_FUNC_REVERSE_SUBTRACT
+			default: __context3D.setBlendFactors(ONE, ONE_MINUS_SOURCE_ALPHA);
 		}
 	}
 

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -352,24 +352,27 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	{
 		if (gl != null)
 		{
-			var values = __getMatrix(transform, AUTO);
-
-			for (i in 0...16)
-			{
-				__matrix[i] = values[i];
-			}
-
+			__getMatrix(transform, NEVER);
 			return __matrix;
 		}
 		else
 		{
-			__matrix.identity();
 			__matrix[0] = transform.a;
 			__matrix[1] = transform.b;
+			__matrix[2] = 0;
+			__matrix[3] = 0;
 			__matrix[4] = transform.c;
 			__matrix[5] = transform.d;
+			__matrix[6] = 0;
+			__matrix[7] = 0;
+			__matrix[8] = 0;
+			__matrix[9] = 0;
+			__matrix[10] = 1;
+			__matrix[11] = 0;
 			__matrix[12] = transform.tx;
 			__matrix[13] = transform.ty;
+			__matrix[14] = 0;
+			__matrix[15] = 1;
 
 			return __matrix;
 		}
@@ -525,37 +528,36 @@ class OpenGLRenderer extends DisplayObjectRenderer
 
 	@:noCompletion private function __getMatrix(transform:Matrix, pixelSnapping:PixelSnapping):Array<Float>
 	{
-		var _matrix = Matrix.__pool.get();
-		_matrix.copyFrom(transform);
-		_matrix.concat(__worldTransform);
+		__matrix[0] = transform.a * __worldTransform.a + transform.b * __worldTransform.c;
+		__matrix[1] = transform.a * __worldTransform.b + transform.b * __worldTransform.d;
+		__matrix[2] = 0;
+		__matrix[3] = 0;
+		__matrix[4] = transform.c * __worldTransform.a + transform.d * __worldTransform.c;
+		__matrix[5] = transform.c * __worldTransform.b + transform.d * __worldTransform.d;
+		__matrix[6] = 0;
+		__matrix[7] = 0;
+		__matrix[8] = 0;
+		__matrix[9] = 0;
+		__matrix[10] = 1;
+		__matrix[11] = 0;
+		__matrix[12] = transform.tx * __worldTransform.a + transform.ty * __worldTransform.c + __worldTransform.tx;
+		__matrix[13] = transform.tx * __worldTransform.b + transform.ty * __worldTransform.d + __worldTransform.ty;
+		__matrix[14] = 0;
+		__matrix[15] = 1;
 
-		if (pixelSnapping == ALWAYS
-			|| (pixelSnapping == AUTO
-				&& _matrix.b == 0
-				&& _matrix.c == 0
-				&& (_matrix.a < 1.001 && _matrix.a > 0.999)
-				&& (_matrix.d < 1.001 && _matrix.d > 0.999)))
-		{
-			_matrix.tx = Math.round(_matrix.tx);
-			_matrix.ty = Math.round(_matrix.ty);
+		if (pixelSnapping == ALWAYS ||
+			(pixelSnapping == AUTO && (__stage == null || __stage.quality == LOW || __stage.quality == MEDIUM)
+				&& __matrix[1] == 0 && __matrix[4] == 0
+				&& __matrix[0] < 1.001 && __matrix[0] > 0.999
+			)	&& __matrix[5] < 1.001 && __matrix[5] > 0.999
+		) {
+			__matrix[12] = Math.round(__matrix[12]);
+			__matrix[13] = Math.round(__matrix[13]);
 		}
 
-		__matrix.identity();
-		__matrix[0] = _matrix.a;
-		__matrix[1] = _matrix.b;
-		__matrix[4] = _matrix.c;
-		__matrix[5] = _matrix.d;
-		__matrix[12] = _matrix.tx;
-		__matrix[13] = _matrix.ty;
 		__matrix.append(__flipped ? __projectionFlipped : __projection);
 
-		for (i in 0...16)
-		{
-			__values[i] = __matrix[i];
-		}
-
-		Matrix.__pool.release(_matrix);
-
+		for (i in 0...16) __values[i] = __matrix[i];
 		return __values;
 	}
 
@@ -967,7 +969,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 		applyAlpha(1);
 		applyBitmapData(source, smooth);
 		applyColorTransform(null);
-		applyMatrix(__getMatrix(source.__renderTransform, AUTO));
+		applyMatrix(__getMatrix(source.__renderTransform, smooth ? NEVER : AUTO));
 		updateShader();
 
 		var vertexBuffer = source.getVertexBuffer(__context3D);

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -249,7 +249,6 @@ class OpenGLRenderer extends DisplayObjectRenderer
 			{
 				__currentShader.__bitmap.input = bitmapData;
 				__currentShader.__bitmap.filter = (smooth && __allowSmoothing) ? LINEAR : NEAREST;
-				__currentShader.__bitmap.mipFilter = MIPNONE;
 				__currentShader.__bitmap.wrap = repeat ? REPEAT : CLAMP;
 			}
 
@@ -257,7 +256,6 @@ class OpenGLRenderer extends DisplayObjectRenderer
 			{
 				__currentShader.__texture.input = bitmapData;
 				__currentShader.__texture.filter = (smooth && __allowSmoothing) ? LINEAR : NEAREST;
-				__currentShader.__texture.mipFilter = MIPNONE;
 				__currentShader.__texture.wrap = repeat ? REPEAT : CLAMP;
 			}
 
@@ -787,9 +785,12 @@ class OpenGLRenderer extends DisplayObjectRenderer
 
 	@:noCompletion private override function __render(object:IBitmapDrawable):Void
 	{
+		if (object.__drawableType == openfl.display._internal.IBitmapDrawableType.STAGE)
+		{
+			__context3D.setDepthTest(false, ALWAYS);
+		}
 		__context3D.setColorMask(true, true, true, true);
 		__context3D.setCulling(NONE);
-		__context3D.setDepthTest(false, ALWAYS);
 		__context3D.setStencilActions();
 		__context3D.setStencilReferenceValue(0, 0, 0);
 		__context3D.setScissorRectangle(null);
@@ -1088,7 +1089,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 				__context3D.__setGLBlend(cacheBlendState);
 			}
 
-				__context3D.__usingComplexBlend = true;
+			__context3D.__usingComplexBlend = true;
 			switch (value) {
 				case DARKEN:
 					if (__context3D.__usingComplexBlend = !__blendMinMaxSupported)
@@ -1110,7 +1111,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 				case COLOR: __context3D.__setGLBlendEquation(0x92AF); // HSL_COLOR_KHR
 				case LUMINOSITY: __context3D.__setGLBlendEquation(0x92B0); // HSL_LUMINOSITY_KHR
 				default: __context3D.__usingComplexBlend = false;
-		}
+			}
 
 			if (__context3D.__usingComplexBlend) return;
 		}


### PR DESCRIPTION
- Optimize getMatrix, Disable forced Pixel Snapping that cannot be changed for Graphics (Used in FlxCamera)
- An attempt to fix darken and lighten blend modes in other platforms, Implement ALPHA, ERASE, INVERT (for gpu that doesnt support KHR_blend_equation_advanced) blend modes
- Only set depth test to false for STAGE drawableType
- Fix forced disabled mipmapping

getMatrix (native platform/opengl renderer) Before:

Take a close look on how it snaps when camera zooms to 1 everytime in a beat hit

https://github.com/user-attachments/assets/dd05b88f-a3dd-4baf-8515-7592eba6b22d



getMatrix (native platform/opengl renderer) After:

https://github.com/user-attachments/assets/487bf364-9d8e-415c-84c3-1c190e4f146a


These are changed to match with web platform