### PR TITLE
Correctly change some setter properties to never

### DIFF
--- a/src/openfl/external/ExternalInterface.hx
+++ b/src/openfl/external/ExternalInterface.hx
@@ -103,7 +103,7 @@ import openfl.utils._internal.Lib;
 		Internet Explorer, or the `name` attribute of the
 		`embed` tag in Netscape.
 	**/
-	public static var objectID(get, null):String;
+	public static var objectID(get, never):String;
 
 	/**
 		Registers an ActionScript method as callable from the container. After a

--- a/src/openfl/net/DatagramSocket.hx
+++ b/src/openfl/net/DatagramSocket.hx
@@ -75,7 +75,7 @@ class DatagramSocket extends EventDispatcher
 	/**
 		Indicates whether this socket object is currently connected to a remote address and port.
 	**/
-	public var connected(get, null):Bool;
+	public var connected(get, never):Bool;
 
 	/**
 		The IP address this socket is bound to on the local machine.
@@ -90,12 +90,12 @@ class DatagramSocket extends EventDispatcher
 	/**
 		The IP address of the remote machine to which this socket is connected.
 	**/
-	public var remoteAddress(get, null):String;
+	public var remoteAddress(get, never):String;
 
 	/**
 		The port on the remote machine to which this socket is connected.
 	**/
-	public var remotePort(get, null):Int;
+	public var remotePort(get, never):Int;
 
 	@:noCompletion private var __udpSocket:UdpSocket;
 	@:noCompletion private var __isReceiving:Bool;

--- a/src/openfl/text/_internal/TextLayout.hx
+++ b/src/openfl/text/_internal/TextLayout.hx
@@ -57,7 +57,7 @@ class TextLayout
 	public var autoHint:Bool;
 	public var direction(get, set):TextDirection;
 	public var font(default, set):Font;
-	@SuppressWarnings("checkstyle:Dynamic") public var glyphs(get, null):Array< #if lime Glyph #else Dynamic #end>;
+	@SuppressWarnings("checkstyle:Dynamic") public var glyphs(get, never):Array< #if lime Glyph #else Dynamic #end>;
 	public var language(get, set):String;
 	public var letterSpacing:Float = 0;
 	@:isVar public var positions(get, null):Array<GlyphPosition>;

--- a/src/openfl/utils/Promise.hx
+++ b/src/openfl/utils/Promise.hx
@@ -62,13 +62,13 @@ class Promise<T>
 		Whether the `Promise` (and related `Future`) has finished with a completion state.
 		This will be `false` if the `Promise` has not been resolved with a completion or error state.
 	**/
-	public var isComplete(get, null):Bool;
+	public var isComplete(get, never):Bool;
 
 	/**
 		Whether the `Promise` (and related `Future`) has finished with an error state.
 		This will be `false` if the `Promise` has not been resolved with a completion or error state.
 	**/
-	public var isError(get, null):Bool;
+	public var isError(get, never):Bool;
 
 	#if commonjs
 	private static function __init__()


### PR DESCRIPTION
This is to ensure that the compiler doesn't generate unnecessary codes to set an impossible variable with null setter property

See also:
- https://github.com/FunkinCrew/lime/pull/49