### PR TITLE
 Specify dialog filter names to fix `FileReference#save` failing silently

### DIFF
--- a/src/openfl/net/FileReference.hx
+++ b/src/openfl/net/FileReference.hx
@@ -870,6 +870,13 @@ class FileReference extends EventDispatcher
 		__urlLoader.load(request);
 
 		#if (lime && !macro)
+		var filters = null;
+		if (defaultFileName != null && Path.extension(defaultFileName).length > 0)
+		{
+			var ext:String = Path.extension(defaultFileName);
+			filters = [new FileDialogFilter('*.$ext', ext)];
+		}
+
 		FileDialog.saveFile(Lib.current.stage.window, function(filepath:String, filter):Void
 		{
 			if (filepath != null)
@@ -880,9 +887,7 @@ class FileReference extends EventDispatcher
 			{
 				saveFileDialog_onCancel();
 			}
-		}, [
-				new FileDialogFilter(null, defaultFileName != null ? Path.extension(defaultFileName) : null)
-		], defaultFileName);
+		}, filters, defaultFileName);
 		#end
 
 		#if (js && html5)
@@ -1119,6 +1124,13 @@ class FileReference extends EventDispatcher
 		}
 
 		#if (lime && !macro)
+		var filters = null;
+		if (defaultFileName != null && Path.extension(defaultFileName).length > 0)
+		{
+			var ext:String = Path.extension(defaultFileName);
+			filters = [new FileDialogFilter('*.$ext', ext)];
+		}
+
 		FileDialog.saveFile(Lib.current.stage.window, function(filepath:String, filter):Void
 		{
 			if (filepath != null)
@@ -1129,9 +1141,7 @@ class FileReference extends EventDispatcher
 			{
 				saveFileDialog_onCancel();
 			}
-		}, [
-				new FileDialogFilter(null, defaultFileName != null ? Path.extension(defaultFileName) : null)
-		], defaultFileName);
+		}, filters, defaultFileName);
 		#end
 	}
 


### PR DESCRIPTION
| No Extension | With Extension |
|--------|--------|
| <img width="724" height="154" alt="no-extension" src="https://github.com/user-attachments/assets/15a2d03a-bbd6-4855-a765-0834eb0028ad" /> | <img width="729" height="155" alt="extension-json" src="https://github.com/user-attachments/assets/5da22102-0a39-4f57-8df4-ce1fcf0f5f42" /> | 