### PR TITLE
GameInputDevice: add `rumble` and `setLED` functions

### DIFF
--- a/src/openfl/ui/GameInputDevice.hx
+++ b/src/openfl/ui/GameInputDevice.hx
@@ -127,6 +127,28 @@ import lime.ui.Gamepad;
 	**/
 	public function stopCachingSamples():Void {}
 
+	/**
+		Start a rumble effect.
+	**/
+	public function rumble(lowFrequency:Float, highFrequency:Float, duration:Int):Void
+	{
+		if (__gamepad != null)
+		{
+			__gamepad.rumble(lowFrequency, highFrequency, duration);
+		}
+	}
+
+	/**
+		Update the LED color.
+	**/
+	public function setLED(red:Int, green:Int, blue:Int):Void
+	{
+		if (__gamepad != null)
+		{
+			__gamepad.setLED(red, green, blue);
+		}
+	}
+
 	// Get & Set Methods
 	@:noCompletion private function get_numControls():Int
 	{


### PR DESCRIPTION
Its pretty self explanatory ig, it requires this pr https://github.com/FunkinCrew/lime/pull/53 to be merged in order to function properly.