### PR TITLE
Add `OES_standard_derivatives` to allow GLES shaders to use fwidth

### DIFF
--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -55,6 +55,7 @@ import lime.math.Matrix4;
 class OpenGLRenderer extends DisplayObjectRenderer
 {
 	@:noCompletion private static var __blendMinMaxSupported:Null<Bool>;
+	@:noCompletion private static var __standardDerivativesSupported:Null<Bool>;
 	@:noCompletion private static var __complexBlendsSupported:Null<Bool>;
 	@:noCompletion private static var __coherentBlendsSupported:Null<Bool>;
 	@:noCompletion private static var __sRGBWriteControlSupported:Null<Bool>;
@@ -171,6 +172,10 @@ class OpenGLRenderer extends DisplayObjectRenderer
 		if (__coherentBlendsSupported == null)
 		{
 			__coherentBlendsSupported = exts.contains("KHR_blend_equation_advanced_coherent");
+		}
+		if (__standardDerivativesSupported == null)
+		{
+			__standardDerivativesSupported = exts.contains("OES_standard_derivatives");
 		}
 
 		#if (js && html5)

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -627,6 +627,7 @@ class Shader
 		}
 
 		var complexBlendsSupported = OpenGLRenderer.__complexBlendsSupported && isFragment;
+		var standardDerivativesSupported = OpenGLRenderer.__standardDerivativesSupported && isFragment;
 
 		#if lime
 		if (__context.__context.type == OPENGL)
@@ -651,6 +652,11 @@ class Shader
 				extensions += "#extension GL_ARB_sample_shading : enable\n";
 			}
 			#end
+		}
+
+		if (standardDerivativesSupported)
+		{
+			extensions += "#extension GL_OES_standard_derivatives : enable\n";
 		}
 
 		// #version must be the first directive and cannot be repeated,


### PR DESCRIPTION
with this patch now i can use fwidth on mobile build of FNF