### PR TITLE
[FEATURE] Accurate Scrolling

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -2287,11 +2287,11 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 		if (deltaMode == PIXELS)
 		{
-			__onMouseWheel(Std.int(deltaX * window.scale), Std.int(deltaY * window.scale), deltaMode);
+			__onMouseWheel(deltaX * window.scale, deltaY * window.scale, deltaMode);
 		}
 		else
 		{
-			__onMouseWheel(Std.int(deltaX), Std.int(deltaY), deltaMode);
+			__onMouseWheel(deltaX, deltaY, deltaMode);
 		}
 	}
 
@@ -3364,9 +3364,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		var targetPoint = Point.__pool.get();
 		targetPoint.setTo(x, y);
 		__displayMatrix.__transformInversePoint(targetPoint);
-		var delta = Std.int(deltaY);
 
-		var event = MouseEvent.__create(MouseEvent.MOUSE_WHEEL, 0, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, targetPoint), target, delta);
+		var event = MouseEvent.__create(MouseEvent.MOUSE_WHEEL, 0, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, targetPoint), target, deltaX, deltaY);
 		event.cancelable = true;
 		__dispatchStack(event, stack);
 		if (event.isDefaultPrevented()) window.onMouseWheel.cancel();

--- a/src/openfl/events/MouseEvent.hx
+++ b/src/openfl/events/MouseEvent.hx
@@ -314,7 +314,9 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `delta` | The number of lines that that each notch on the mouse wheel represents. |
+		| `delta` | The number of lines that that each notch on the mouse wheel represents. **It is preferenced to use the `deltaY` property as this one is used for compatiblity!** |
+		| `deltaX` | The number of characters on the x axis that that each notch on the mouse wheel represents. |
+		| `deltaY` | The number of lines on the y axis that that each notch on the mouse wheel represents. |
 		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
 		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
@@ -506,6 +508,8 @@ class MouseEvent extends Event
 	public var ctrlKey:Bool;
 
 	/**
+		**It is preferenced to use the `deltaY` property as this one is used for compatiblity!**
+
 		Indicates how many lines should be scrolled for each unit the user rotates
 		the mouse wheel. A positive delta value indicates an upward scroll; a
 		negative value indicates a downward scroll. Typical values are 1 to 3, but
@@ -513,7 +517,28 @@ class MouseEvent extends Event
 		device and operating system and is usually configurable by the user. This
 		property applies only to the `MouseEvent.mouseWheel` event.
 	**/
-	public var delta:Int;
+	public var delta(get, never):Int;
+
+	/**
+		Indicates how many characters should be scrolled for each unit the user swipes
+		the mouse wheel on the x axis (not supported everywhere). A positive delta value
+		indicates an right scroll; a negative value indicates a left scroll. Typical
+		values are 1 to 3 (can go up to 10+ on some laptops), but faster rotation may
+		produce larger values. This setting depends on the device and operating system
+		and is usually configurable by the user. This property applies onlyto the
+		`MouseEvent.mouseWheel` event.
+	**/
+	public var deltaX:Float;
+
+	/**
+		Indicates how many lines should be scrolled for each unit the user rotates
+		the mouse wheel. A positive delta value indicates an upward scroll; a
+		negative value indicates a downward scroll. Typical values are 1 to 3
+		(can go up to 10+ on some laptops), but faster rotation may produce larger values.
+		This setting depends on the device and operating system and is usually configurable
+		by the user. This property applies only to the `MouseEvent.mouseWheel` event.
+	**/
+	public var deltaY:Float;
 
 	/**
 		If `true`, the `relatedObject` property is set to `null` for reasons related to
@@ -590,6 +615,15 @@ class MouseEvent extends Event
 
 	@:noCompletion private var __updateAfterEventFlag:Bool;
 
+	#if openfljs
+	@:noCompletion private static function __init__()
+	{
+		untyped Object.defineProperty(MouseEvent.prototype, "delta", {
+			get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_delta (); }")
+		});
+	}
+	#end
+
 	/**
 		Creates an Event object that contains information about mouse events.
 		Event objects are passed as parameters to event listeners.
@@ -640,8 +674,8 @@ class MouseEvent extends Event
 							 `MouseEvent.mouseWheel` event.
 	**/
 	public function new(type:String, bubbles:Bool = true, cancelable:Bool = false, localX:Float = 0, localY:Float = 0, relatedObject:InteractiveObject = null,
-			ctrlKey:Bool = false, altKey:Bool = false, shiftKey:Bool = false, buttonDown:Bool = false, delta:Int = 0, commandKey:Bool = false,
-			controlKey:Bool = false, clickCount:Int = 0)
+			ctrlKey:Bool = false, altKey:Bool = false, shiftKey:Bool = false, buttonDown:Bool = false, deltaX:Float = 0, deltaY:Float = 0,
+			commandKey:Bool = false, controlKey:Bool = false, clickCount:Int = 0)
 	{
 		super(type, bubbles, cancelable);
 
@@ -650,7 +684,8 @@ class MouseEvent extends Event
 		this.ctrlKey = ctrlKey;
 		this.bubbles = bubbles;
 		this.relatedObject = relatedObject;
-		this.delta = delta;
+		this.deltaX = deltaX;
+		this.deltaY = deltaY;
 		this.localX = localX;
 		this.localY = localY;
 		this.buttonDown = buttonDown;
@@ -667,8 +702,8 @@ class MouseEvent extends Event
 
 	public override function clone():MouseEvent
 	{
-		var event = new MouseEvent(type, bubbles, cancelable, localX, localY, relatedObject, ctrlKey, altKey, shiftKey, buttonDown, delta, commandKey,
-			controlKey, clickCount);
+		var event = new MouseEvent(type, bubbles, cancelable, localX, localY, relatedObject, ctrlKey, altKey, shiftKey, buttonDown, deltaX, deltaY,
+			commandKey, controlKey, clickCount);
 		event.target = target;
 		event.currentTarget = currentTarget;
 		event.eventPhase = eventPhase;
@@ -688,7 +723,8 @@ class MouseEvent extends Event
 			"altKey",
 			"shiftKey",
 			"buttonDown",
-			"delta"
+			"deltaX",
+			"deltaY"
 		]);
 	}
 
@@ -706,9 +742,9 @@ class MouseEvent extends Event
 	}
 
 	@:noCompletion private static function __create(type:String, button:Int, clickCount:Int, stageX:Float, stageY:Float, local:Point,
-			target:InteractiveObject, delta:Int = 0):MouseEvent
+			target:InteractiveObject, deltaX:Float = 0, deltaY:Float = 0):MouseEvent
 	{
-		var event = new MouseEvent(type, true, false, local.x, local.y, null, __ctrlKey, __altKey, __shiftKey, __buttonDown, delta, __commandKey,
+		var event = new MouseEvent(type, true, false, local.x, local.y, null, __ctrlKey, __altKey, __shiftKey, __buttonDown, deltaX, deltaY, __commandKey,
 			__controlKey, clickCount);
 		event.stageX = stageX;
 		event.stageY = stageY;
@@ -725,7 +761,8 @@ class MouseEvent extends Event
 		altKey = false;
 		ctrlKey = false;
 		relatedObject = null;
-		delta = 0;
+		deltaX = 0;
+		deltaY = 0;
 		localX = 0;
 		localY = 0;
 		buttonDown = false;
@@ -738,6 +775,12 @@ class MouseEvent extends Event
 		stageY = Math.NaN;
 
 		__updateAfterEventFlag = false;
+	}
+
+	// Get & Set Methods
+	@:noCompletion private function get_delta():Int
+	{
+		return Std.int(deltaY);
 	}
 }
 #else


### PR DESCRIPTION
## All Pull Requests Needed

- https://github.com/FunkinCrew/flixel/pull/20
- https://github.com/FunkinCrew/lime/pull/82
- https://github.com/FunkinCrew/openfl/pull/35

## What does this specific PR do?
The OpenFL PR removes the rounding in the mouse `deltaY` scrolling and now exposes `deltaX` through `MouseEvent` for Flixel to get it and use it for `FlxMouse`

## Description
This series of PRs adds support for decimal wheel support in Flixel (and adds flicking so scrolling fast makes a velocity for the wheel flick manager) so its not rounded from the OpenFL side and direction is fixed from the Lime (NDLL) Side