### PR TITLE
Fix ApplicationMain.hx preventing the game from opening

### DIFF
--- a/assets/templates/haxe/ApplicationMain.hx
+++ b/assets/templates/haxe/ApplicationMain.hx
@@ -288,6 +288,13 @@ class ApplicationMain
 		};
 		::end::
 	}
+
+	#if !macro
+	@:noCompletion @:dox(hide) public static function __init__()
+	{
+		var init = lime.app.Application;
+	}
+	#end
 }
 
 #if !macro


### PR DESCRIPTION
This fixes an issue where the game doesn't open. This isn't a problem for Funkin' because it uses an older version of the ApplicationMain template, but because other projects want to use the Funkin' forks, this needs to be done.

As it turns out, the __init__ function is needed.