### PR TITLE
Fix ApplicationMain compile error

### DIFF
--- a/assets/templates/haxe/ApplicationMain.hx
+++ b/assets/templates/haxe/ApplicationMain.hx
@@ -108,10 +108,6 @@ class ApplicationMain
 
 		app.createWindow(attributes);
 		::end::
-		#else
-		app.window.context.attributes.background = ::WIN_BACKGROUND::;
-		app.window.frameRate = ::WIN_FPS::;
-		#end
 
 		var preloader = getPreloader();
 		app.preloader.onProgress.add (function(loaded, total)


### PR DESCRIPTION
Some code was kept from before flash was removed and ApplicationMain is unable to compile.